### PR TITLE
Add oryp10, sync oryp9 and oryp10 with gaze17

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ there, please contact support for Windows driver information.
 - [Oryx Pro (oryp7)](#oryx-pro-oryp7)
 - [Oryx Pro (oryp8)](#oryx-pro-oryp8)
 - [Oryx Pro (oryp9)](#oryx-pro-oryp9)
+- [Oryx Pro (oryp10)](#oryx-pro-oryp10)
 
 ### Adder WS (addw2)
 
@@ -192,16 +193,32 @@ there, please contact support for Windows driver information.
   - Download the ZIP file, extract, and run `SetupSerialIO.exe`
 - [Intel WiFi Driver](./drivers/wifi-phwfw01690_21.110.1.1_g.zip)
   - Download the ZIP file, extract, and run `UWD/Win64/Installer/WirelessSetup.exe`
+- Other drivers are installed automatically through Windows Update
 
-  ### Oryx Pro (oryp9)
+### Oryx Pro (oryp9)
 
-- [Intel Chipset Driver](./drivers/chipset-10.1.18950.8297-public-mup.zip)
+- [Intel Chipset Driver](./drivers/chipset-10.1.19074.8314-public-mup.zip)
   - Download the ZIP file, extract, and run `SetupChipset.exe`
 - [Intel HID Event Filter Driver](./drivers/hideventfilterdriver-2.2.1.386_rs5_19h1_20h1_21h2_certified.zip)
   - Download the ZIP file, extract, and run `Installer/Setup.exe`
-- [Intel SerialIO Driver](./drivers/serialio-30.100.2134.22_pv_adl-lp_22h2.zip)
+- [Intel SerialIO Driver](./drivers/serialio_30.100.2148.1_pv_adl-pch_21h2.zip)
   - Download the ZIP file, extract, and run `SetupSerialIO.exe`
-- [Intel WiFi Driver](./drivers/wifi-phwfw01690_21.110.1.1_g.zip)
+- [Intel Thunderbolt Driver](./drivers/tbt_dch_sw_rev86.zip)
+  - Download the ZIP file, extract, and run `TBT_DCH_SW_Rev86/Public/Installer_Executable/Thunderbolt(TM) Software Installer.exe`
+- [Intel WiFi Driver](./drivers/wifi-phwfw06118_22.145.0.2_g.zip)
   - Download the ZIP file, extract, and run `UWD/Win64/Installer/WirelessSetup.exe`
-  
+- Other drivers are installed automatically through Windows Update
+
+### Oryx Pro (oryp10)
+
+- [Intel Chipset Driver](./drivers/chipset-10.1.19074.8314-public-mup.zip)
+  - Download the ZIP file, extract, and run `SetupChipset.exe`
+- [Intel HID Event Filter Driver](./drivers/hideventfilterdriver-2.2.1.386_rs5_19h1_20h1_21h2_certified.zip)
+  - Download the ZIP file, extract, and run `Installer/Setup.exe`
+- [Intel SerialIO Driver](./drivers/serialio_30.100.2148.1_pv_adl-pch_21h2.zip)
+  - Download the ZIP file, extract, and run `SetupSerialIO.exe`
+- [Intel Thunderbolt Driver](./drivers/tbt_dch_sw_rev86.zip)
+  - Download the ZIP file, extract, and run `TBT_DCH_SW_Rev86/Public/Installer_Executable/Thunderbolt(TM) Software Installer.exe`
+- [Intel WiFi Driver](./drivers/wifi-phwfw06118_22.145.0.2_g.zip)
+  - Download the ZIP file, extract, and run `UWD/Win64/Installer/WirelessSetup.exe`
 - Other drivers are installed automatically through Windows Update


### PR DESCRIPTION
Was there a reason oryp9 used older drivers than gaze17?

Rendered: https://github.com/system76/windows-drivers/blob/oryp10/README.md