### PR TITLE
Update RPL-HX drivers to 2024-WW28

### DIFF
--- a/drivers/intel/rpl-hx/2024-WW28/30.100.2417.30-ADL.zip
+++ b/drivers/intel/rpl-hx/2024-WW28/30.100.2417.30-ADL.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbc60f164ad9f1e034d03e0aa2d42e591ecdfb23225de781a9f3e2fccaed5dea
+size 3245708

--- a/drivers/intel/rpl-hx/2024-WW28/Chipset-10.1.19899.8597-Public-Client.zip
+++ b/drivers/intel/rpl-hx/2024-WW28/Chipset-10.1.19899.8597-Public-Client.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:102d776cd47abf43dab6f3f31a754b8053fcbf759460a1a3d377b6cc582c8059
+size 7871287

--- a/drivers/intel/rpl-hx/2024-WW28/TBT_DCH_SW_Rev93.zip
+++ b/drivers/intel/rpl-hx/2024-WW28/TBT_DCH_SW_Rev93.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1aa3f57e7b61b42a414f280933887318a1aa10bf73e08a58146df02ebf544be2
+size 254476503

--- a/drivers/intel/rpl-hx/2024-WW28/wifi-SBHWFW01112_23.60.1.2G.zip
+++ b/drivers/intel/rpl-hx/2024-WW28/wifi-SBHWFW01112_23.60.1.2G.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89b31792f109e2725c9c31fc132222bc9e59bb480cb38161835f61c6bc4454b3
+size 90362589

--- a/drivers/intel/rpl-hx/README.md
+++ b/drivers/intel/rpl-hx/README.md
@@ -10,12 +10,12 @@ parentheses matches the sticker on your unit:
 
 ### Drivers
 
-- [Intel Chipset Driver](./2023-WW26/Chipset-10.1.19502.8391-Public-MUP.zip)
+- [Intel Chipset Driver](./2024-WW28/Chipset-10.1.19899.8597-Public-Client.zip)
   - Download the ZIP file, extract, and run `SetupChipset.exe`
-- [Intel SerialIO Driver](./2023-WW26/SerialIO_30.100.2237.26_v2_RPL_ADL-PCH_22H2.zip)
-  - Download the ZIP file, extract, and run `SerialIO_30.100.2237.26_v2_RPL_ADL-PCH_22H2/SetupSerialIO.exe`
-- [Intel Thunderbolt Driver](./2023-WW26/TBT_DCH_SW_Rev90.zip)
-  - Download the ZIP file, extract, and run `TBT_DCH_SW_Rev90/Public/Installer_Executable/Thunderbolt(TM) Software Installer.exe`
-- [Intel WiFi Driver](./2023-WW26/wifi-PHWFW07641_22.230.0.8_P.zip)
-  - Download the ZIP file, extract, and run `Install/UWD/Win64/Installer/WirelessSetup.exe`
+- [Intel SerialIO Driver](./2024-WW28/30.100.2417.30-ADL.zip)
+  - Download the ZIP file, extract, and run `30.100.2417.30-ADL/SetupSerialIO.exe`
+- [Intel Thunderbolt Driver](./2024-WW28/TBT_DCH_SW_Rev93.zip)
+  - Download the ZIP file, extract, and run `TBT_DCH_SW_Rev93/Public/Installer_Executable/Thunderbolt(TM) Software Installer.exe`
+- [Intel WiFi Driver](./2024-WW28/wifi-SBHWFW01112_23.60.1.2G.zip)
+  - Download the ZIP file, extract, and run `UWD/Win64/Installer/WirelessSetup.exe`
 - Other drivers are installed automatically through Windows Update


### PR DESCRIPTION
Add drivers from RPL-HX Refresh PV BKC WW28-2024.

- Kit: 826983
- Version: Production Version(24H2)
- Updated: 2024-07-09

The following changes were made:

- TBT: Repacked to remove NDA component.
- WiFi: Repacked to fix Win64 installer.